### PR TITLE
fix TypeError: 'WorkspaceReply' object is not subscriptable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ Requirements
 
 * python >= 3.4
 * i3 >= v3.11 or sway (git master branch)
-* [i3ipc-python](https://i3ipc-python.readthedocs.io/en/latest/)
+* [i3ipc-python](https://i3ipc-python.readthedocs.io/en/latest/) >= v2.0.1
 * dmenu or rofi (optional)

--- a/i3-quickterm
+++ b/i3-quickterm
@@ -114,9 +114,9 @@ def move_back(conn, selector):
 
 
 def pop_it(conn, mark_name, pos='top', ratio=0.25):
-    ws, _ = get_current_workspace(conn)
-    wx, wy = ws['rect']['x'], ws['rect']['y']
-    wwidth, wheight = ws['rect']['width'], ws['rect']['height']
+    ws = get_current_workspace(conn)
+    wx, wy = ws.rect.x, ws.rect.y
+    wwidth, wheight = ws.rect.width, ws.rect.height
 
     width = wwidth
     height = int(wheight*ratio)
@@ -138,24 +138,17 @@ def pop_it(conn, mark_name, pos='top', ratio=0.25):
 
 
 def get_current_workspace(conn):
-    ws = [w for w in conn.get_workspaces() if w['focused']][0]
-    tree = conn.get_tree()
-
-    # wname = workspace['name']
-    ws_tree = [c for c in tree.descendents()
-               if c.type == 'workspace' and c.name == ws['name']][0]
-
-    return ws, ws_tree
+    return conn.get_tree().find_focused().workspace()
 
 
 def toggle_quickterm_select(conf, hist=None):
     """Hide a quickterm visible on current workspace or prompt
     the user for a shell type"""
     conn = i3ipc.Connection()
-    ws, ws_tree = get_current_workspace(conn)
+    ws = get_current_workspace(conn)
 
     # is there a quickterm opened in the current workspace?
-    qt = ws_tree.find_marked(MARK_QT_PATTERN)
+    qt = ws.find_marked(MARK_QT_PATTERN)
     if qt:
         qt = qt[0]
         move_back(conn, '[con_id={}]'.format(qt.id))
@@ -206,9 +199,8 @@ def term_title(shell):
 
 def toggle_quickterm(conf, shell):
     conn = i3ipc.Connection()
-    tree = conn.get_tree()
     shell_mark = MARK_QT.format(shell)
-    qt = tree.find_marked(shell_mark)
+    qt = conn.get_tree().find_marked(shell_mark)
 
     # does it exist already?
     if len(qt) == 0:
@@ -221,7 +213,7 @@ def toggle_quickterm(conf, shell):
         os.execvp(term_cmd[0], term_cmd)
     else:
         qt = qt[0]
-        ws, ws_tree = get_current_workspace(conn)
+        ws = get_current_workspace(conn)
 
         move_back(conn, '[con_id={}]'.format(qt.id))
         if qt.workspace().name != ws.name:


### PR DESCRIPTION
- access Con members by dot operator (ie do ws.rect.x instead of
  ws['rect']['x']);
- simplify get_current_workspace(): only return what the function name
  says;

Fixes #9

Fyi am running

    i3ipc 2.1.1 (note 2.0.1 introduced bunch of breaking changes)
    i3 version 4.17-2-g9df9e62b (2019-08-04, branch "gaps-next")