### PR TITLE
Added config argument to argparser

### DIFF
--- a/i3_quickterm/main.py
+++ b/i3_quickterm/main.py
@@ -209,7 +209,9 @@ def toggle_quickterm(conf, shell):
     # does it exist already?
     if len(qt) == 0:
         term = TERMS.get(conf["term"], conf["term"])
-        qt_cmd = "{} -i {}".format(sys.argv[0], shell)
+        qt_cmd = f"{sys.argv[0]} -i {shell}"
+        if "_config" in conf:
+            qt_cmd += f" -c {conf['_config']}"
 
         term_cmd = expand_command(
             term,
@@ -250,6 +252,7 @@ def main():
     conf = copy.deepcopy(DEFAULT_CONF)
     if args.config:
         conf.update(read_conf(args.config))
+        conf["_config"] = args.config
     else:
         conf.update(read_conf(conf_path()))
 

--- a/i3_quickterm/main.py
+++ b/i3_quickterm/main.py
@@ -240,6 +240,7 @@ def launch_inplace(conf, shell):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--in-place", dest="in_place", action="store_true")
+    parser.add_argument("-c", "--config", dest="config", type=str, help="read config from specified file")
     parser.add_argument("shell", metavar="SHELL", nargs="?")
     parser.add_argument(
         "--version", action="version", version="%(prog)s {}".format(__version__)
@@ -247,7 +248,10 @@ def main():
     args = parser.parse_args()
 
     conf = copy.deepcopy(DEFAULT_CONF)
-    conf.update(read_conf(conf_path()))
+    if args.config:
+        conf.update(read_conf(args.config))
+    else:
+        conf.update(read_conf(conf_path()))
 
     if args.shell is None:
         toggle_quickterm_select(conf)


### PR DESCRIPTION
usage -c CONFIG or --config CONFIG

Motivation:
This option allows you to load specified config file.
This can be useful for separate configs for sway and i3.